### PR TITLE
Update README.md and credit line

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,94 @@
-# EZ-FLASH OMEGA Simple kernel
+# SimpleLight 
+Hello all!
+
+I have been working on a new theme for the EZ-Flash Omega, and I call it Simple.
+
+It is a nice rounded theme with both light and dark options, and allows for many, many more file types to be used, such as Master System and ZX Spectrum ROMs to be launched, along with the ability to view bitmap images, read text documents, and play music. (shoutouts to Kuwanger for PogoShell)
+
+I completely redid all of the graphics, along with using a different font.
+
+It also uses the 2019-05-04 version of Goomba Color, and has a save backup feature (shoutouts to Veikkos)
+
+Hope everyone likes it!
+
+Official forum thread:
+https://gbatemp.net/threads/new-theme-for-ez-flash-omega.520665/
+
+## Installation instructions:
+
+_**Follow the installation instructions in the !!!!!!!!!IMPORTANT!!!!!!!!!!!.TXT file in the GBAtemp package before reporting issues.**_
+
+1. Copy the SYSTEM and BACKUP folder to the root of the SD Card.
+2. Move your IMGS, SAVER, RTS, and PATCH folders to SYSTEM.
+3. If you want the light theme, copy ezkernel-light.bin to the root of the SD Card. If you want the dark thing, do the same with ezkernel-dark.bin
+4. Rename the new kernel file to ezkernel.bin
+5. You're done!
+
+## Registered file types:
+### Game ROMs
+    .gba - GBA ROM
+    .bin - GBA ROM
+    .mb - GBA Multiboot ROM
+    .agb - GBA ROM
+    .col - ColecoVision ROM (Requires Cologne) \*
+    .gb - Game Boy ROM (Goomba Color)
+    .gbc - Game Boy Color ROM (Goomba Color)
+    .gg - Game Gear ROM (SMSAdvance)
+    .rom - MSX Cartridge ROM (MSXAdvance) \*\*
+    .ngp - Neo Geo Pocket ROM (NGPAdvance)
+    .ngc - Neo Geo Pocket ROM (NGPAdvance)
+    .ngpc - Neo Geo Pocket Color ROM (NGPAdvance)
+    .nes  - NES ROM File (PocketNES)
+    .pce - PC-Engine ROM File (PCEAdvance)
+    .sms - Sega Master System ROM File (SMSAdvance)
+    .sg - Sega SG-1000 ROM File (SMSAdvance)
+    .sv - Watara Supervision ROM File (Wasabi)
+    .ws - WonderSwan ROM File (SwanAdvance)
+    .wsc - WonderSwan Color ROM File (SwanAdvance)
+    .z80 - 48k ZX-Spectrum Z80 ROM (ZXAdvance)
+    .c8 - Chip-8 ROM (Chip8Adv (My First Emulator! :D))
+    .arc - 4kb Emerson Arcadia 2001 ROM File
+
+### Media
+    .jpg - JPEG Image
+    .jpeg - JPEG Image
+    .mod - ProTracker Module file
+    .bmp - Bitmap Image
+    .pcx - ZSoft Paintbrush PCX image
+    .mid - MIDI sequence
+    .nsf - NES Music file (Nintendo Sound File)
+    .vgm - SMS/GG music file
+    .vga - aPlib Compressed SMS/GG music file
+    .vgl - LZ77 Compressed SMS/GG music file
+    .txt - Text Document
+    .wav - Wave Sound (formatted in GSM 6.10)
+    .k3m - Krawall Advance Sound
+    .sb - MaxMod sound bank
+    .lz - LZ77 Compressed Image
+    .raw - Uncompressed Mode 3 Bitmap
+    .ap - aPlib compressed Mode 3 Bitmap
+    .bgf - BoyScout module
+    .mda - Sharp X68000 Music
+    .cwz - CWZ Music (IDK what exactly it is, but it was included with PogoShell 1.2)
+
+*\* For cologne, you have to make the ROM yourself.*
+*\*\* MSXAdvance uses the C-BIOS, so I can redistribute the emulator.*
+
+##### Cologne Emulator Guide:
+1. Download the latest version of Cologne.
+2. Open the EXE file.
+3. Take a blank file, and also add the Official Colecovision BIOS.
+4. Create col.gba in the PLUG folder.
+
+# EZ-FLASH OMEGA Kernel
 
 ### How to build 
 
-1. Install devkitPro
-2. Set the following environment variables to their correct directories: `DEVKITPRO, DEVKITARM, LIBGBA`
-3. Comment or uncomment the `#define DARK` line in `draw.h`. If uncommented, a dark theme is generated.
-4. Run the command `make`. If done successfully, this should give you an `ezkernel.bin` file.
-5. Follow the installation instructions in the `!!!!!!!!!IMPORTANT!!!!!!!!!!!.TXT` file in the GBAtemp package.
-4. Update your flashcart and enjoy! :)
+The original developers of the EZ-Flash Omega kernel recommend using devkitARM_r47. Sometime after devkitARM_r50, any level of optimization began preventing PogoShell plugins from properly generating. The code has been adjusted since then to remove optimizations and so will compile and run properly on the most recent build of devkitARM (as of September 29, 2020).
+	
+##### Compiling light and dark themes:
+1. Comment or uncomment the "#define DARK" line in "draw.h". If uncommented, a dark theme is generated.
+2. Set the following environment variables in system, or modify the value in build.bat, based on your installation path
+    ```PATH,DEVKITARM,DEVKITPRO,LIBGBA```
+3. Double click on build.bat under Windows. If everything is set up, you will get ezkernel.bin
+	

--- a/source/draw.h
+++ b/source/draw.h
@@ -1,8 +1,7 @@
 #include <gba_base.h>
 
-#define DARK
-
-
+// Uncomment (or comment) the following line to generate a dark themed ezkernel.bin
+//#define DARK
 
 void Clear(u16 x, u16 y, u16 w, u16 h, u16 c, u8 isDrawDirect);
 void ClearWithBG(u16* pbg,u16 x, u16 y, u16 w, u16 h, u8 isDrawDirect);

--- a/source/ezkernel.c
+++ b/source/ezkernel.c
@@ -88,6 +88,8 @@
 
 char* mod_ee;
 
+char credit_line_1[64] = "";
+
 u8 in_recently_play;
 
 FM_FILE_FS pFilename_buffer[MAX_files]EWRAM_BSS;
@@ -200,7 +202,7 @@ void Show_help_window()
 	DrawHZText12("L+Start:", 0, 3, 65, gl_color_selected, 1);
 	DrawHZText12(gl_LSTART_help, 0, 52, 65, gl_color_text, 1);
 	DrawHZText12(gl_online_manual, 0, 240 - 70 - 10, 74, gl_color_text, 1);
-	DrawHZText12(gl_theme_credit, 0, 4, 105, gl_color_selected, 1);
+	DrawHZText12(credit_line_1, 0, 4, 105, gl_color_selected, 1);
 	DrawHZText12(gl_theme_credit2, 0, 4, 120, gl_color_selected, 1);
 	DrawHZText12("K:1.06 F:7", 0, 4, 143, gl_color_text, 1);
 	while (1) {
@@ -1319,6 +1321,18 @@ void CheckLanguage(void)
 	else { //ÖÐÎÄ
 		LoadChinese();
 	}
+	//Modify credit string
+	strcpy(credit_line_1, gl_theme_credit);
+	strcat(credit_line_1, " ");
+	strcat(credit_line_1, gl_sl_version);
+	strcat(credit_line_1, " ");
+	
+#ifdef DARK
+	strcat(credit_line_1, gl_sl_dark);
+#else
+	strcat(credit_line_1, gl_sl_light);
+#endif
+	
 }
 //---------------------------------------------------------------------------------
 void CheckSwitch(void)
@@ -1404,7 +1418,7 @@ void IWRAM_CODE make_pogoshell_arguments(TCHAR* cmdname, TCHAR* filename, u32 cm
 {
 	u32* p, addr;
 	char* ptr, * cmdptr, * fileptr;
-	int i = 0;
+	//int i = 0; // not used
 
 	addr = 0x08000000 + cmdsize;
 
@@ -2593,12 +2607,13 @@ re_showfile:
 						break;
 					}
 					else if (MENU_line == 1) {
-						//delete lastest geme
+						//display message saying to delete last game first
 						if (show_offset + file_select + 1 == game_total_NOR) {
 							Block_Erase(gl_norOffset - pNorFS[show_offset + file_select].filesize);
 						}
 						else {
-							DrawHZText12(gl_lastest_game, 0, 66, 118 - 15, gl_color_text, 1);
+							DrawHZText12(gl_lastest_game, 0, 66, 88, gl_color_text, 1);
+							DrawHZText12(gl_lastest_game2, 0, 66, 103, gl_color_text, 1);
 							wait_btn();
 						}
 						page_num = NOR_list;

--- a/source/lang.c
+++ b/source/lang.c
@@ -11,10 +11,15 @@ char* gl_file_overflow;
 char* gl_theme_credit;
 char* gl_theme_credit2;
 
+char* gl_sl_version;
+char* gl_sl_dark;
+char* gl_sl_light;
+
 char* gl_generating_emu;
 
 char* gl_menu_btn;
 char* gl_lastest_game;
+char* gl_lastest_game2;
 
 char* gl_writing;
 
@@ -93,6 +98,11 @@ char* gl_copying_data;
 
 unsigned char* ASC_DATA;
 
+//Simple light version info
+const char sl_version[]="3.41";
+const char sl_dark_theme[]="Dark";
+const char sl_light_theme[]="Light";
+
 //中文
 const char zh_init_error[]="TF卡初始化失败";
 const char zh_power_off[]="关机";
@@ -102,7 +112,8 @@ const char zh_file_overflow[]="文件太大,不能加载";
 
 const char zh_menu_btn[]=" (B)取消    (A)确定";
 const char zh_writing[]="正在写入...";
-const char zh_lastest_game[]="请选择最后一个游戏";
+const char zh_lastest_game[]=" ";
+const char zh_lastest_game2[]="请选择最后一个游戏";
 
 const char zh_time[] ="     时间";
 const char zh_Mon[]="一";
@@ -128,7 +139,7 @@ const char zh_set_btn[]="设置";
 const char zh_ok_btn[]="保存";
 const char zh_formatnor_info[]="确定?大约4分钟";
 
-const char zh_theme_credit[]="Simple主题 v3.41";
+const char zh_theme_credit[]="Simple主题";
 const char zh_theme_credit2[]="by Sterophonick";
 
 const char zh_check_sav[]="检查SAV文件";
@@ -205,7 +216,8 @@ const char en_file_overflow[]="The file is too big.";
 
 const char en_menu_btn[]=" (B) No     (A) OK";
 const char en_writing[]="Writing...";
-const char en_lastest_game[]="Select the lastest";
+const char en_lastest_game[]="Error: Start from";
+const char en_lastest_game2[]="       the bottom";
 
 const char en_time[]="     Time";
 const char en_Mon[]="Mon";
@@ -220,7 +232,7 @@ const char en_addon[]="    Addon";
 const char en_reset[]="Reset";
 const char en_rts[]="Savestate";
 const char en_sleep[]="Sleep";
-const char en_cheat[]="Cheat";
+const char en_cheat[]="Cheats";
 
 const char en_hot_key[] ="Sleep key";
 const char en_hot_key2[]=" Menu key";
@@ -232,8 +244,8 @@ const char en_ok_btn[]=" OK";
 const char en_formatnor_info1[]="Sure? This will be";
 const char en_formatnor_info2[]=" about 4 minutes.";
 
-const char en_theme_credit[]="Simple v3.41 by";
-const char en_theme_credit2[]="Sterophonick.";
+const char en_theme_credit[]="Simple";
+const char en_theme_credit2[]="by Sterophonick";
 
 const char en_check_sav[]="Checking Save Data...";
 const char en_make_sav[] ="Creating Save Data...";
@@ -310,10 +322,15 @@ void LoadChinese(void)
 	gl_file_overflow = (char*)zh_file_overflow;
 	gl_theme_credit = (char*)zh_theme_credit;
 	gl_theme_credit2 = (char*)zh_theme_credit2;
-
+	
+	gl_sl_version = (char*)sl_version;
+	gl_sl_dark = (char*)sl_dark_theme;
+	gl_sl_light = (char*)sl_light_theme;
+	
 	gl_menu_btn = (char*)zh_menu_btn;
 	gl_writing = (char*)zh_writing;
 	gl_lastest_game = (char*)zh_lastest_game;
+	gl_lastest_game2 = (char*)zh_lastest_game2;
 	
 	
 	gl_time = (char*)zh_time;	
@@ -393,10 +410,31 @@ void LoadChinese(void)
 	ASC_DATA = ASC_DATA_OLD;
 }
 //---------------------------------------------------------------------------------
+
+void cat(char *a, char *b)
+{
+   while(*a)
+      a++;
+     
+   while(*b)
+   {
+      *a = *b;
+      b++;
+      a++;
+   }
+   *a = '\0';
+}
+
+
 void LoadEnglish(void)
 {
 	gl_theme_credit = (char*)en_theme_credit;
 	gl_theme_credit2 = (char*)en_theme_credit2;
+	
+	gl_sl_version = (char*)sl_version;
+	gl_sl_dark = (char*)sl_dark_theme;
+	gl_sl_light = (char*)sl_light_theme;
+	
 	gl_init_error = (char*)en_init_error;
 	gl_power_off = (char*)en_power_off;
 	gl_init_ok = (char*)en_init_ok;
@@ -406,6 +444,7 @@ void LoadEnglish(void)
 	gl_menu_btn = (char*)en_menu_btn;
 	gl_writing = (char*)en_writing;
 	gl_lastest_game = (char*)en_lastest_game;
+	gl_lastest_game2 = (char*)en_lastest_game2;
 	
 	gl_time = (char*)en_time;	
 	gl_Mon = (char*)en_Mon;

--- a/source/lang.h
+++ b/source/lang.h
@@ -11,10 +11,15 @@ extern char* gl_file_overflow;
 extern char* gl_theme_credit;
 extern char* gl_theme_credit2;
 
+extern char* gl_sl_version;
+extern char* gl_sl_dark;
+extern char* gl_sl_light;
+
 extern char* gl_generating_emu;
 
 extern char* gl_menu_btn;
 extern char* gl_lastest_game;
+extern char* gl_lastest_game2;
 
 extern char* gl_writing;
 extern char* gl_time;


### PR DESCRIPTION
Just something that makes updating the version a little faster, and an update to the readme file

Update README.md
Added instruction comment to draw.h
Comment seemingly unused variable in ezkernel.c relating to pogoshell plugins
Minor adjustment to credit line in lang.c (move 'by' to second credit line)
Localization fix (lastest -> latest)
Migrate version and theme names to their own section in lang.c
Add theme name to credit line 1 in ezkernel.c